### PR TITLE
Particle model element authoring

### DIFF
--- a/css/particle-modeler.less
+++ b/css/particle-modeler.less
@@ -87,6 +87,23 @@
     padding: 4px;
   }
 
+  h4 {
+    padding-top: 3px;
+    padding-bottom: 3px;
+  }
+
+  .authoring-slider {
+    display: flex;
+    flex-direction: column;
+
+    &.mini {
+      flex-direction: row;
+      justify-content: space-between;
+      width: 300px;
+      margin-bottom: -8px;
+    }
+  }
+
   .delete-icon {
     position: absolute;
     top: -73px;

--- a/css/particle-modeler.less
+++ b/css/particle-modeler.less
@@ -111,3 +111,20 @@
     pointer-events: none;
   }
 }
+
+tbody tr:nth-child(odd) {
+  background-color: #cccccc;
+}
+
+tbody tr:nth-child(even) {
+  background-color: #efefef;
+}
+
+table {
+  background-color: white;
+  border: 1px solid #777;
+}
+
+td {
+  text-align: center;
+}

--- a/js/particle-modeler/authoring.js
+++ b/js/particle-modeler/authoring.js
@@ -79,12 +79,14 @@ const Authoring = (props) => {
     for (let i = 0, ii = pairwiseUI.use.length; i < ii; i++) {
       for (let j = i, jj=pairwiseUI.use[i].length; j < jj; j++) {
         if (pairwiseUI.use[i][j]) {
+          let pair = (i+1) + "-" + (j+1);
+
           rows.push(
-            <tr>
-              <td>{i+1}-{j+1}</td>
-              <td>{pairwiseUI.use[i][j]}</td>
-              <td>{pairwiseUI.epsilon[i][j]}</td>
-              <td>{pairwiseUI.sigma[i][j]}</td>
+            <tr key={pair}>
+              <td key={"id" + pair}>{pair}</td>
+              <td key={"use" + pair}>{pairwiseUI.use[i][j]}</td>
+              <td key={"epsilon" + pair}>{pairwiseUI.epsilon[i][j]}</td>
+              <td key={"sigma" + pair}>{pairwiseUI.sigma[i][j]}</td>
             </tr>
           );
         }
@@ -92,12 +94,14 @@ const Authoring = (props) => {
     }
     return (
       <table>
-        <tr>
-          <th>Pair</th>
-          <th>Use?</th>
-          <th>Epsilon</th>
-          <th>Sigma</th>
-        </tr>
+        <thead>
+          <tr>
+            <th>Pair</th>
+            <th>Use?</th>
+            <th>Epsilon</th>
+            <th>Sigma</th>
+          </tr>
+        </thead>
         <tbody>
           { rows }
         </tbody>

--- a/js/particle-modeler/authoring.js
+++ b/js/particle-modeler/authoring.js
@@ -7,35 +7,37 @@ const Authoring = (props) => {
   }
 
   let createCheckboxInput = function(prop, values) {
+    let label = values.label ? <span>{values.label}: </span> : null;
     return (
       <div key={prop}>
-        {values.label}:
+        { label }
         <input type="checkbox" data-prop={prop} checked={values.value} onChange={handleCheckboxChange} />
       </div>
     );
   }
 
-  let createSliderInput = function(prop, values, mini) {
+  let createSliderInput = function(prop, values, mini, table) {
     let scale = (values.max - values.min > 1) ? 1 : 1/(values.max - values.min),
         handleChange = function(evt, val) {
           val /= scale;
           val = val < 1 && val > -1 && val != 0 ? val.toPrecision(3) : val;
           props.onChange(prop, val);
         },
-        wrapperClass = "authoring-slider";
+        wrapperClass = "authoring-slider",
+        label = values.label ? <span>{values.label}: </span> : null;
     if (mini) {
       wrapperClass += " mini";
     }
     return (
       <div className={wrapperClass} key={prop}>
-        <div>{values.label}: {values.value}</div>
+        <div>{ label }{ values.value }</div>
         <Slider
           min={values.min * scale}
           max={values.max * scale}
           value={values.value * scale}
           step={((values.max - values.min) * scale) / 100}
           onChange={handleChange}
-          sliderStyle={{ marginTop: 5, marginBottom: 5, width: "200px" }}
+          sliderStyle={{ marginTop: 5, marginBottom: 5, width: table ? "160px" : "200px" }}
         />
       </div>
     );
@@ -59,12 +61,58 @@ const Authoring = (props) => {
     }
   }
 
+  function createPairwiseTable() {
+    let pairwiseUI = {use: [[],[],[]], epsilon: [[],[],[]], sigma: [[],[],[]]}
+    for (let key in props) {
+      let prop = props[key];
+      if (prop.hasOwnProperty("element1")) {
+        let ui;
+        if (prop.property == "use") {
+          ui = createCheckboxInput(key, prop);
+        } else {
+          ui = createSliderInput(key, prop, false, true);
+        }
+        pairwiseUI[prop.property][prop.element1][prop.element2] = ui;
+      }
+    }
+    let rows = [];
+    for (let i = 0, ii = pairwiseUI.use.length; i < ii; i++) {
+      for (let j = i, jj=pairwiseUI.use[i].length; j < jj; j++) {
+        if (pairwiseUI.use[i][j]) {
+          rows.push(
+            <tr>
+              <td>{i+1}-{j+1}</td>
+              <td>{pairwiseUI.use[i][j]}</td>
+              <td>{pairwiseUI.epsilon[i][j]}</td>
+              <td>{pairwiseUI.sigma[i][j]}</td>
+            </tr>
+          );
+        }
+      }
+    }
+    return (
+      <table>
+        <tr>
+          <th>Pair</th>
+          <th>Use?</th>
+          <th>Epsilon</th>
+          <th>Sigma</th>
+        </tr>
+        <tbody>
+          { rows }
+        </tbody>
+      </table>
+    )
+  }
+
 
   let inputs = Object.keys(props).map(modelInputMap),
 
       elem1 = Object.keys(props).map(elementInputMap(0)),
       elem2 = Object.keys(props).map(elementInputMap(1)),
-      elem3 = Object.keys(props).map(elementInputMap(2));
+      elem3 = Object.keys(props).map(elementInputMap(2)),
+
+      pairwiseTable = createPairwiseTable();
 
 
 
@@ -78,6 +126,8 @@ const Authoring = (props) => {
       { elem2 }
       <h4>Element 3</h4>
       { elem3 }
+      <h3>Pairwise Forces</h3>
+      { pairwiseTable }
     </div>
   )
 }

--- a/js/particle-modeler/authoring.js
+++ b/js/particle-modeler/authoring.js
@@ -15,16 +15,20 @@ const Authoring = (props) => {
     );
   }
 
-  let createSliderInput = function(prop, values) {
-    let scale = (values.max - values.min > 1) ? 1 : 1/(values.max - values.min) ,
+  let createSliderInput = function(prop, values, mini) {
+    let scale = (values.max - values.min > 1) ? 1 : 1/(values.max - values.min),
         handleChange = function(evt, val) {
           val /= scale;
           val = val < 1 && val > -1 && val != 0 ? val.toPrecision(3) : val;
           props.onChange(prop, val);
-        }
+        },
+        wrapperClass = "authoring-slider";
+    if (mini) {
+      wrapperClass += " mini";
+    }
     return (
-      <div key={prop}>
-        {values.label}: {values.value}
+      <div className={wrapperClass} key={prop}>
+        <div>{values.label}: {values.value}</div>
         <Slider
           min={values.min * scale}
           max={values.max * scale}
@@ -37,20 +41,43 @@ const Authoring = (props) => {
     );
   }
 
-  let inputs = Object.keys(props).map(function(key) {
-    if (!props[key].hasOwnProperty("label")) {
+  function modelInputMap(key) {
+    if (!props[key].hasOwnProperty("label") || props[key].hasOwnProperty("element")) {
       return null;
     } else if (typeof props[key].value === "number") {
       return createSliderInput(key, props[key]);
     } else {
       return createCheckboxInput(key, props[key]);
     }
-  });
+  }
+
+  function elementInputMap(element) {
+    return function(key) {
+      if (props[key].hasOwnProperty("element") && props[key].element == element) {
+        return createSliderInput(key, props[key], true);
+      }
+    }
+  }
+
+
+  let inputs = Object.keys(props).map(modelInputMap),
+
+      elem1 = Object.keys(props).map(elementInputMap(0)),
+      elem2 = Object.keys(props).map(elementInputMap(1)),
+      elem3 = Object.keys(props).map(elementInputMap(2));
+
+
 
   return (
     <div className="authoring-form">
       <h3>Authoring</h3>
       { inputs }
+      <h4>Element 1</h4>
+      { elem1 }
+      <h4>Element 2</h4>
+      { elem2 }
+      <h4>Element 3</h4>
+      { elem3 }
     </div>
   )
 }

--- a/js/particle-modeler/authoring.js
+++ b/js/particle-modeler/authoring.js
@@ -19,7 +19,7 @@ const Authoring = (props) => {
     let scale = (values.max - values.min > 1) ? 1 : 1/(values.max - values.min) ,
         handleChange = function(evt, val) {
           val /= scale;
-          val = val < 1 && val > 0 ? val.toPrecision(2) : val;
+          val = val < 1 && val > -1 && val != 0 ? val.toPrecision(3) : val;
           props.onChange(prop, val);
         }
     return (

--- a/js/particle-modeler/index.js
+++ b/js/particle-modeler/index.js
@@ -57,13 +57,22 @@ export default class Interactive extends PureComponent {
   }
 
   setModelProps(prevState = {}) {
-    let newModelProperties = {}
-    for (let prop in this.state.model) {
-      if (this.state[prop] !== "" && this.state[prop] !== prevState[prop]) {
-        newModelProperties[prop] = parseToPrimitive(this.state[prop]);
+    let newModelProperties = {},
+        newElementProperties = [{}, {}, {}];
+    for (let prop in authorableProps) {
+      let value = this.state[prop];
+      if (value !== "" && value !== prevState[prop]) {
+        if (value.hasOwnProperty("element")) {
+          newElementProperties[value.element][value.property] = parseToPrimitive(value);
+        } else {
+          newModelProperties[prop] = parseToPrimitive(value);
+        }
       }
     }
     api.set(newModelProperties);
+    for (let elem in newElementProperties) {
+      api.setElementProperties(elem, newElementProperties[elem]);
+    }
   }
 
   componentWillUpdate(nextProps, nextState) {

--- a/js/particle-modeler/index.js
+++ b/js/particle-modeler/index.js
@@ -93,9 +93,9 @@ export default class Interactive extends PureComponent {
     api = lab.scriptingAPI;
     api.onDrag('atom', (x, y, d, i) => {
       if (d.pinned === 1) {
-        let el = d.element,
+        let el = d.element - 3,
             newState = {};
-        api.setAtomProperties(i, {pinned: 0});
+        api.setAtomProperties(i, {pinned: 0, element: el});
         newState["showNewAtom"+el] = false;
         this.setState(newState);
         this.addNewDraggableAtom(el);
@@ -136,7 +136,7 @@ export default class Interactive extends PureComponent {
 
   addNewDraggableAtom(el=0) {
     let y = atomBox.y - (el * atomBox.spacing),
-        added = api.addAtom({x: atomBox.x, y: y, element: el, draggable: 1, pinned: 1});
+        added = api.addAtom({x: atomBox.x, y: y, element: (el+3), draggable: 1, pinned: 1});
     if (!added) {
       setTimeout(() => this.addNewDraggableAtom(el), 2000);
     } else {

--- a/js/particle-modeler/index.js
+++ b/js/particle-modeler/index.js
@@ -58,20 +58,36 @@ export default class Interactive extends PureComponent {
 
   setModelProps(prevState = {}) {
     let newModelProperties = {},
-        newElementProperties = [{}, {}, {}];
+        newElementProperties = [{}, {}, {}],
+        newPairwiseProperties = [[{}, {}, {}], [{}, {}, {}], [{}, {}, {}]];
     for (let prop in authorableProps) {
       let value = this.state[prop];
       if (value !== "" && value !== prevState[prop]) {
         if (value.hasOwnProperty("element")) {
           newElementProperties[value.element][value.property] = parseToPrimitive(value);
+        } else if (value.hasOwnProperty("element1")) {
+          newPairwiseProperties[parseToPrimitive(value.element1)][parseToPrimitive(value.element2)][value.property] = parseToPrimitive(value);
         } else {
           newModelProperties[prop] = parseToPrimitive(value);
         }
       }
     }
+
     api.set(newModelProperties);
     for (let elem in newElementProperties) {
       api.setElementProperties(elem, newElementProperties[elem]);
+    }
+    for (let elem1 = 0; elem1 < newPairwiseProperties.length; elem1++) {
+      for (let elem2 = 0; elem2 < newPairwiseProperties[elem1].length; elem2++) {
+        let pairValue = newPairwiseProperties[elem1][elem2];
+        if (Object.keys(pairValue).length > 0) {
+          if (this.state[`pair${(elem1+1)}${(elem2+1)}Forces`].value) {
+            api.setPairwiseLJProperties(elem1, elem2, { sigma: parseToPrimitive(this.state[`pair${(elem1+1)}${(elem2+1)}Sigma`].value), epsilon: parseToPrimitive(this.state[`pair${(elem1+1)}${(elem2+1)}Epsilon`].value) });
+          } else {
+            api.removePairwiseLJProperties(elem1, elem2);
+          }
+        }
+      }
     }
   }
 

--- a/js/particle-modeler/index.js
+++ b/js/particle-modeler/index.js
@@ -4,6 +4,8 @@ import Lab from 'react-lab';
 import NewAtomBin from './new-atom-bin';
 import Authoring from './authoring';
 import models from './models/';
+// Set of authorable properties which can be overwritten by the url hash.
+import authorableProps from './models/authorable-props';
 import { getStateFromHashWithDefaults, getDiffedHashParams, parseToPrimitive } from '../utils';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import DeleteIcon from 'material-ui/svg-icons/action/delete-forever';
@@ -29,54 +31,13 @@ let atomBox = {
       height: 0.146
     };
 
-// Set of authorable properties which can be overwritten by the url hash.
-let authoredDefaults = {
-  authoring: false,
-  temperatureControl: {
-    label: "Heatbath",
-    value: false
-  },
-  targetTemperature: {
-    label: "Heatbath temperature",
-    value: 0,
-    min: 0,
-    max: 1000
-  },
-  gravitationalField: {
-    label: "Gravity",
-    value: 0,
-    min: 0,
-    max: 1e-5
-  },
-  timeStep: {
-    label: "Time step",
-    value: 1,
-    min: 0,
-    max: 5
-  },
-  viscosity: {
-    label: "Viscosity",
-    value: 1,
-    min: 0,
-    max: 10
-  },
-  showFreezeButton: {
-    label: "Show Freeze Button",
-    value: false
-  },
-  startWithAtoms: {
-    label: "Start With Existing Atoms",
-    value: false
-  }
-};
-
 export default class Interactive extends PureComponent {
 
   constructor(props) {
     super(props);
 
     let hashParams = window.location.hash.substring(1),
-        authoredState = getStateFromHashWithDefaults(hashParams, authoredDefaults),
+        authoredState = getStateFromHashWithDefaults(hashParams, authorableProps),
         model = authoredState.startWithAtoms.value ? models.baseModel : models.emptyModel;
 
     this.state = {
@@ -113,7 +74,7 @@ export default class Interactive extends PureComponent {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    let hash = getDiffedHashParams(this.state, authoredDefaults);
+    let hash = getDiffedHashParams(this.state, authorableProps);
     window.location.hash = hash;
 
     this.setModelProps(prevState);

--- a/js/particle-modeler/models/authorable-props.js
+++ b/js/particle-modeler/models/authorable-props.js
@@ -38,7 +38,7 @@ module.exports = {
   },
 
   element1Sigma: {
-    label: "Element 1 Sigma",
+    label: "Sigma",
     element: 0,
     property: "sigma",
     value: 0.1915,
@@ -46,7 +46,7 @@ module.exports = {
     max: 0.5
   },
   element1Epsilon: {
-    label: "Element 1 Epsilon",
+    label: "Epsilon",
     element: 0,
     property: "epsilon",
     value: -0.05,
@@ -54,7 +54,7 @@ module.exports = {
     max: 0
   },
   element1Mass: {
-    label: "Element 1 Mass",
+    label: "Mass",
     element: 0,
     property: "mass",
     value: 20,
@@ -63,7 +63,7 @@ module.exports = {
   },
 
   element2Sigma: {
-    label: "Element 2 Sigma",
+    label: "Sigma",
     element: 1,
     property: "sigma",
     value: 0.1915,
@@ -71,7 +71,7 @@ module.exports = {
     max: 0.5
   },
   element2Epsilon: {
-    label: "Element 2 Epsilon",
+    label: "Epsilon",
     element: 1,
     property: "epsilon",
     value: -0.1,
@@ -79,7 +79,7 @@ module.exports = {
     max: 0
   },
   element2Mass: {
-    label: "Element 2 Mass",
+    label: "Mass",
     element: 1,
     property: "mass",
     value: 100,
@@ -88,7 +88,7 @@ module.exports = {
   },
 
   element3Sigma: {
-    label: "Element 3 Sigma",
+    label: "Sigma",
     element: 2,
     property: "sigma",
     value: 0.1915,
@@ -96,7 +96,7 @@ module.exports = {
     max: 0.5
   },
   element3Epsilon: {
-    label: "Element 3 Epsilon",
+    label: "Epsilon",
     element: 2,
     property: "epsilon",
     value: -0.000001,
@@ -104,7 +104,7 @@ module.exports = {
     max: 0
   },
   element3Mass: {
-    label: "Element 3 Mass",
+    label: "Mass",
     element: 2,
     property: "mass",
     value: 30,

--- a/js/particle-modeler/models/authorable-props.js
+++ b/js/particle-modeler/models/authorable-props.js
@@ -110,5 +110,143 @@ module.exports = {
     value: 30,
     min: 10,
     max: 1000
+  },
+
+  pair11Forces: {
+    element1: 0,
+    element2: 0,
+    property: "use",
+    value: false
+  },
+  pair11Epsilon: {
+    element1: 0,
+    element2: 0,
+    property: "epsilon",
+    value: -0.05,
+    min: -0.5,
+    max: 0
+  },
+  pair11Sigma: {
+    element1: 0,
+    element2: 0,
+    property: "sigma",
+    value: 0.1915,
+    min: 0.01,
+    max: 0.5
+  },
+
+  pair12Forces: {
+    element1: 0,
+    element2: 1,
+    property: "use",
+    value: false
+  },
+  pair12Epsilon: {
+    element1: 0,
+    element2: 1,
+    property: "epsilon",
+    value: -0.05,
+    min: -0.5,
+    max: 0
+  },
+  pair12Sigma: {
+    element1: 0,
+    element2: 1,
+    property: "sigma",
+    value: 0.1915,
+    min: 0.01,
+    max: 0.5
+  },
+
+  pair13Forces: {
+    element1: 0,
+    element2: 2,
+    property: "use",
+    value: false
+  },
+  pair13Epsilon: {
+    element1: 0,
+    element2: 2,
+    property: "epsilon",
+    value: -0.05,
+    min: -0.5,
+    max: 0
+  },
+  pair13Sigma: {
+    element1: 0,
+    element2: 2,
+    property: "sigma",
+    value: 0.1915,
+    min: 0.01,
+    max: 0.5
+  },
+
+  pair22Forces: {
+    element1: 1,
+    element2: 1,
+    property: "use",
+    value: false
+  },
+  pair22Epsilon: {
+    element1: 1,
+    element2: 1,
+    property: "epsilon",
+    value: -0.05,
+    min: -0.5,
+    max: 0
+  },
+  pair22Sigma: {
+    element1: 1,
+    element2: 1,
+    property: "sigma",
+    value: 0.1915,
+    min: 0.01,
+    max: 0.5
+  },
+
+  pair23Forces: {
+    element1: 1,
+    element2: 2,
+    property: "use",
+    value: false
+  },
+  pair23Epsilon: {
+    element1: 1,
+    element2: 2,
+    property: "epsilon",
+    value: -0.05,
+    min: -0.5,
+    max: 0
+  },
+  pair23Sigma: {
+    element1: 1,
+    element2: 2,
+    property: "sigma",
+    value: 0.1915,
+    min: 0.01,
+    max: 0.5
+  },
+
+  pair33Forces: {
+    element1: 2,
+    element2: 2,
+    property: "use",
+    value: false
+  },
+  pair33Epsilon: {
+    element1: 2,
+    element2: 2,
+    property: "epsilon",
+    value: -0.05,
+    min: -0.5,
+    max: 0
+  },
+  pair33Sigma: {
+    element1: 2,
+    element2: 2,
+    property: "sigma",
+    value: 0.1915,
+    min: 0.01,
+    max: 0.5
   }
 }

--- a/js/particle-modeler/models/authorable-props.js
+++ b/js/particle-modeler/models/authorable-props.js
@@ -35,5 +35,80 @@ module.exports = {
   startWithAtoms: {
     label: "Start With Existing Atoms",
     value: false
+  },
+
+  element1Sigma: {
+    label: "Element 1 Sigma",
+    element: 0,
+    property: "sigma",
+    value: 0.1915,
+    min: 0.01,
+    max: 0.5
+  },
+  element1Epsilon: {
+    label: "Element 1 Epsilon",
+    element: 0,
+    property: "epsilon",
+    value: -0.05,
+    min: -0.5,
+    max: 0
+  },
+  element1Mass: {
+    label: "Element 1 Mass",
+    element: 0,
+    property: "mass",
+    value: 20,
+    min: 10,
+    max: 1000
+  },
+
+  element2Sigma: {
+    label: "Element 2 Sigma",
+    element: 1,
+    property: "sigma",
+    value: 0.1915,
+    min: 0.01,
+    max: 0.5
+  },
+  element2Epsilon: {
+    label: "Element 2 Epsilon",
+    element: 1,
+    property: "epsilon",
+    value: -0.1,
+    min: -0.5,
+    max: 0
+  },
+  element2Mass: {
+    label: "Element 2 Mass",
+    element: 1,
+    property: "mass",
+    value: 100,
+    min: 10,
+    max: 1000
+  },
+
+  element3Sigma: {
+    label: "Element 3 Sigma",
+    element: 2,
+    property: "sigma",
+    value: 0.1915,
+    min: 0.01,
+    max: 0.5
+  },
+  element3Epsilon: {
+    label: "Element 3 Epsilon",
+    element: 2,
+    property: "epsilon",
+    value: -0.000001,
+    min: -0.5,
+    max: 0
+  },
+  element3Mass: {
+    label: "Element 3 Mass",
+    element: 2,
+    property: "mass",
+    value: 30,
+    min: 10,
+    max: 1000
   }
 }

--- a/js/particle-modeler/models/authorable-props.js
+++ b/js/particle-modeler/models/authorable-props.js
@@ -1,0 +1,39 @@
+module.exports = {
+  authoring: false,
+  temperatureControl: {
+    label: "Heatbath",
+    value: false
+  },
+  targetTemperature: {
+    label: "Heatbath temperature",
+    value: 0,
+    min: 0,
+    max: 1000
+  },
+  gravitationalField: {
+    label: "Gravity",
+    value: 0,
+    min: 0,
+    max: 1e-5
+  },
+  timeStep: {
+    label: "Time step",
+    value: 1,
+    min: 0,
+    max: 5
+  },
+  viscosity: {
+    label: "Viscosity",
+    value: 1,
+    min: 0,
+    max: 10
+  },
+  showFreezeButton: {
+    label: "Show Freeze Button",
+    value: false
+  },
+  startWithAtoms: {
+    label: "Start With Existing Atoms",
+    value: false
+  }
+}

--- a/js/particle-modeler/models/empty-model.json
+++ b/js/particle-modeler/models/empty-model.json
@@ -38,6 +38,7 @@
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
+    "aminoAcidLabels": false,
     "showChargeSymbols": true,
     "showVDWLines": false,
     "VDWLinesCutoff": "medium",
@@ -72,24 +73,81 @@
     },
     "forceVectorsDirectionOnly": false
   },
-  "pairwiseLJProperties": [],
+  "pairwiseLJProperties": [
+    {
+      "sigma": 0.3,
+      "epsilon": 0,
+      "element1": 0,
+      "element2": 3
+    },
+    {
+      "sigma": 0.3,
+      "epsilon": 0,
+      "element1": 0,
+      "element2": 4
+    },
+    {
+      "sigma": 0.3,
+      "epsilon": 0,
+      "element1": 0,
+      "element2": 5
+    },
+    {
+      "sigma": 0.3,
+      "epsilon": 0,
+      "element1": 1,
+      "element2": 3
+    },
+    {
+      "sigma": 0.3,
+      "epsilon": 0,
+      "element1": 1,
+      "element2": 4
+    },
+    {
+      "sigma": 0.3,
+      "epsilon": 0,
+      "element1": 1,
+      "element2": 5
+    },
+    {
+      "sigma": 0.3,
+      "epsilon": 0,
+      "element1": 2,
+      "element2": 3
+    },
+    {
+      "sigma": 0.3,
+      "epsilon": 0,
+      "element1": 2,
+      "element2": 4
+    },
+    {
+      "sigma": 0.3,
+      "epsilon": 0,
+      "element1": 2,
+      "element2": 5
+    }
+  ],
   "elements": {
     "mass": [
       20,
       100,
       30,
-      80,
-      600
+      20,
+      100,
+      30
     ],
     "sigma": [
       0.19149999618530272,
       0.19149999618530272,
       0.19149999618530272,
-      0.28,
-      0.3
+      0.19149999618530272,
+      0.19149999618530272,
+      0.19149999618530272
     ],
-    "epsilon": [-0.05, -0.1, -0.000001, -0.1, -0.1],
-    "color": [-855310, -9066941, -13159, -2539040, -855310]
+    "epsilon": [-0.05, -0.1, -0.000001, 0, 0, 0],
+    "color": [-855310, -9066941, -13159, -855310, -9066941, -13159]
   },
   "atoms": {
     "x": [

--- a/js/particle-modeler/models/model.json
+++ b/js/particle-modeler/models/model.json
@@ -38,6 +38,7 @@
     "chargeShading": false,
     "useThreeLetterCode": true,
     "aminoAcidColorScheme": "hydrophobicity",
+    "aminoAcidLabels": false,
     "showChargeSymbols": true,
     "showVDWLines": false,
     "VDWLinesCutoff": "medium",
@@ -72,24 +73,81 @@
     },
     "forceVectorsDirectionOnly": false
   },
-  "pairwiseLJProperties": [],
+  "pairwiseLJProperties": [
+    {
+      "sigma": 0.3,
+      "epsilon": 0,
+      "element1": 0,
+      "element2": 3
+    },
+    {
+      "sigma": 0.3,
+      "epsilon": 0,
+      "element1": 0,
+      "element2": 4
+    },
+    {
+      "sigma": 0.3,
+      "epsilon": 0,
+      "element1": 0,
+      "element2": 5
+    },
+    {
+      "sigma": 0.3,
+      "epsilon": 0,
+      "element1": 1,
+      "element2": 3
+    },
+    {
+      "sigma": 0.3,
+      "epsilon": 0,
+      "element1": 1,
+      "element2": 4
+    },
+    {
+      "sigma": 0.3,
+      "epsilon": 0,
+      "element1": 1,
+      "element2": 5
+    },
+    {
+      "sigma": 0.3,
+      "epsilon": 0,
+      "element1": 2,
+      "element2": 3
+    },
+    {
+      "sigma": 0.3,
+      "epsilon": 0,
+      "element1": 2,
+      "element2": 4
+    },
+    {
+      "sigma": 0.3,
+      "epsilon": 0,
+      "element1": 2,
+      "element2": 5
+    }
+  ],
   "elements": {
     "mass": [
       20,
       100,
       30,
-      80,
-      600
+      20,
+      100,
+      30
     ],
     "sigma": [
       0.19149999618530272,
       0.19149999618530272,
       0.19149999618530272,
-      0.28,
-      0.3
+      0.19149999618530272,
+      0.19149999618530272,
+      0.19149999618530272
     ],
-    "epsilon": [-0.05, -0.1, -0.000001, -0.1, -0.1],
-    "color": [-855310, -9066941, -13159, -2539040, -855310]
+    "epsilon": [-0.05, -0.1, -0.000001, 0, 0, 0],
+    "color": [-855310, -9066941, -13159, -855310, -9066941, -13159]
   },
   "atoms": {
     "x": [

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "material-ui": "^0.16.4",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
-    "react-lab": "0.5.0",
+    "react-lab": "0.7.0",
     "react-tap-event-plugin": "^2.0.1",
     "sensor-labquest-2-interface": "^0.1.0"
   },


### PR DESCRIPTION
Adds ability to set element properties, custom LJ properties, and makes the New Atom box non-interacting with the model.

The custom LJ props made the authoring file quite a bit uglier due to the large number of props, but this was kept to allow it to continue to work with the url-binding system and the automatic widget generation. Possibly in retrospect another system would have been cleaner.