### PR TITLE
Mixing Lab model

### DIFF
--- a/js/components/lab-model.js
+++ b/js/components/lab-model.js
@@ -6,6 +6,8 @@ import interactive from '../../models/interactive.json';
 
 import '../../css/lab-model.less';
 
+let api, lab;
+
 export default class LabModel extends PureComponent {
   constructor(props) {
     super(props);
@@ -39,7 +41,62 @@ export default class LabModel extends PureComponent {
   }
 
   handleModelLoad() {
-    this.setState({loading: false});
+    this.setState({ loading: false });
+    const { mixing } = this.props;
+    api = lab.scriptingAPI;
+    if (!api) return null;
+    api.start();
+    if (mixing != null) {
+      var particlesHot = [];
+      var particlesCold = [];
+      var hot = "B";
+      if (mixing.aTemp > mixing.bTemp) {
+        hot = "A";
+      }
+      var isReady = false;
+      var tickCount = 0;
+      var mixingTimeTicks = 200;
+      api.onPropertyChange('time', function (t) {
+        // this will fire every tick
+        if (!isReady && particlesHot.length == 0) {
+          var textboxes = api.get('textBoxes');
+          if (textboxes) {
+            for (let i = 0; i < textboxes.length; i++) {
+              var hostParticle = textboxes[i].hostIndex;
+              if (textboxes[i].text == hot) {
+                if (api.getAtomProperties(hostParticle) != null) {
+                  particlesHot.push(hostParticle);
+                }
+              }
+              else {
+                if (api.getAtomProperties(hostParticle) != null) {
+                  particlesCold.push(hostParticle);
+                }
+              }
+            }
+            isReady = true;
+          }
+        }
+        if (isReady && particlesHot.length > 0) {
+          if (tickCount < mixingTimeTicks) {
+            if (tickCount % 10 == 0) {
+                var energyA = tickCount / mixingTimeTicks;
+                api.addKEToAtoms(energyA, particlesCold);
+                api.addKEToAtoms(mixingTimeTicks - tickCount, particlesHot);
+                // Sanity check particle properties to prevent model diverge
+                for (var i = 0, a; i < api.getNumberOfAtoms(); i++) {
+                  a = api.getAtomProperties(i);
+                  if (Math.abs(i.ax) > 0.1 || Math.abs(i.ay) > 0.1) {
+                    i.ax = 0.0001;
+                    i.ay = 0.0001;
+                  }
+                }
+            }
+            tickCount++;
+          }
+        }
+      });
+    }
   }
 
   render() {
@@ -51,11 +108,10 @@ export default class LabModel extends PureComponent {
           {loading &&
             <CircularProgress size={width * 0.5} thickness={7} style={{position: 'absolute', top: width * 0.25, left: width * 0.25}}/>
           }
-          <Lab interactive={interactive} model={model}
+          <Lab ref={node => lab = node} interactive={interactive} model={model}
                props={this.labProps}
                width={width} height={height}
                onModelLoad={this.handleModelLoad}
-               playing={true}
                embeddableSrc={embeddableSrc}/>
           <div className="overlay"/>
         </div>
@@ -70,6 +126,7 @@ LabModel.propTypes = {
   height: PropTypes.number,
   temperature: PropTypes.number,
   tempScale: PropTypes.func,
+  mixing: PropTypes.object,
   // timeStep can be also scaled with temperature to amplify difference in particles speed.
   timeStepScale: PropTypes.func
 };

--- a/js/components/mixing-view.js
+++ b/js/components/mixing-view.js
@@ -59,8 +59,8 @@ export default class MixingView extends PureComponent {
 
   renderTwoThermoscopes(mode) {
     const { showHideButtons, showPlayButtons, showCelsius } = this.props;
-    const active = mode === MixingMode.TwoThermoscope 
-      || mode === MixingMode.RemovalInstructions 
+    const active = mode === MixingMode.TwoThermoscope
+      || mode === MixingMode.RemovalInstructions
       || mode === MixingMode.Frozen
       || mode === MixingMode.MixInstructions;
     const frozen = mode >= MixingMode.Frozen;
@@ -80,7 +80,7 @@ export default class MixingView extends PureComponent {
             showPlayButtons={showPlayButtons}
             showCelsius={showCelsius}
             onTemperatureChage={this.handleTemperatureChange('a')}
-            forceCover={true}
+            forceCover={frozen}
             frozen={frozen}
           />
         </div>
@@ -98,7 +98,7 @@ export default class MixingView extends PureComponent {
             showPlayButtons={showPlayButtons}
             showCelsius={showCelsius}
             onTemperatureChage={this.handleTemperatureChange('b')}
-            forceCover={true}
+            forceCover={frozen}
             frozen={frozen}
           />
         </div>
@@ -122,6 +122,7 @@ export default class MixingView extends PureComponent {
     const { showHideButtons, showPlayButtons, showCelsius } = this.props;
     const { aTemp, bTemp } = this.state;
     const active = mode === MixingMode.OneThermoscope;
+    const frozen = mode >= MixingMode.Frozen;
     return (
       <div className={active ? 'visible' : 'invisible'}>
         <div className="thermoscope-container center mixing">
@@ -140,7 +141,7 @@ export default class MixingView extends PureComponent {
             showCelsius={showCelsius}
             aPegged={aTemp}
             bPegged={bTemp}
-            forceCover={true}
+            forceCover={frozen}
             mixingValues={{ aTemp, bTemp }}
             />}
         </div>
@@ -166,7 +167,7 @@ export default class MixingView extends PureComponent {
           onClose={this.handleContinue(MixingMode.StartMixTransition)} />
       </div>
     );
-  } 
+  }
 
   render() {
     const { mode } = this.state;

--- a/js/components/mixing-view.js
+++ b/js/components/mixing-view.js
@@ -125,7 +125,8 @@ export default class MixingView extends PureComponent {
     return (
       <div className={active ? 'visible' : 'invisible'}>
         <div className="thermoscope-container center mixing">
-          <Thermoscope
+          {active &&
+            <Thermoscope
             className="mixing"
             sensor={sensor}
             material={'liquid'}
@@ -140,7 +141,8 @@ export default class MixingView extends PureComponent {
             aPegged={aTemp}
             bPegged={bTemp}
             forceCover={true}
-          />
+            mixingValues={{ aTemp, bTemp }}
+            />}
         </div>
         <div className="thermoscope-b-alt" />
       </div>

--- a/js/components/mixing-view.js
+++ b/js/components/mixing-view.js
@@ -142,7 +142,6 @@ export default class MixingView extends PureComponent {
             aPegged={aTemp}
             bPegged={bTemp}
             forceCover={frozen}
-            mixingValues={{ aTemp, bTemp }}
             />}
         </div>
         <div className="thermoscope-b-alt" />

--- a/js/components/mixing-view.js
+++ b/js/components/mixing-view.js
@@ -141,7 +141,7 @@ export default class MixingView extends PureComponent {
             showCelsius={showCelsius}
             aPegged={aTemp}
             bPegged={bTemp}
-            forceCover={frozen}
+            forceCover={true}
             />}
         </div>
         <div className="thermoscope-b-alt" />

--- a/js/components/thermoscope.js
+++ b/js/components/thermoscope.js
@@ -109,7 +109,7 @@ export default class Thermoscope extends PureComponent {
 
   render() {
     const { temperature, materialType, materialIdx, liveData, label, paused, hidden } = this.state;
-    const { embeddableSrc, showMaterialControls, showHideButtons, showPlayButtons, showCelsius, className, aPegged, bPegged, forceCover, frozen } = this.props;
+    const { embeddableSrc, showMaterialControls, showHideButtons, showPlayButtons, showCelsius, className, aPegged, bPegged, forceCover, frozen, mixingValues } = this.props;
 
     const model = models[materialType][materialIdx];
     let material = MATERIAL_TYPES.indexOf(materialType > -1) ? materialType : 'solid';
@@ -133,7 +133,7 @@ export default class Thermoscope extends PureComponent {
       <div className={`thermoscope ${className}`}>
         <div className={`label ${label.toLowerCase()} ${this.modelToClassName(model)}`} />
         {!hidden && [
-            !frozen && 
+            !frozen &&
               <LabModel temperature={temperature}
                 model={model.json}
                 tempScale={tempScale}
@@ -142,11 +142,12 @@ export default class Thermoscope extends PureComponent {
                 coulombForcesSettings={model.coulombForcesSettings}
                 width={MODEL_WIDTH} height={MODEL_HEIGHT}
                 embeddableSrc={embeddableSrc}
+                mixing={mixingValues}
                 key="lab"
             />,
             <div className={`zoom-fade ${label.toLowerCase()} ${this.modelToClassName(model)}`} key="fade"/>,
             <div className={`zoom-circle ${label.toLowerCase()} ${this.modelToClassName(model)}`} key="circle"/>,
-            <Dial 
+            <Dial
               className={`${className ? className : ''} ${label.toLowerCase()} ${this.modelToClassName(model)}`}
               temperature={temperature}
               showCelsius={showCelsius}
@@ -159,7 +160,7 @@ export default class Thermoscope extends PureComponent {
               frozen={frozen}
             />,
             (isFinite(bPegged) &&
-              <Dial 
+              <Dial
                 className={`${className} ${label.toLowerCase()} ${this.modelToClassName(model)} dial2`}
                 temperature={temperature}
                 showCelsius={showCelsius}
@@ -174,7 +175,7 @@ export default class Thermoscope extends PureComponent {
           ]
         }
         {showHideButtons &&
-          <StyledButton 
+          <StyledButton
             className={`show-hide ${label.toLowerCase()}`}
             onClick={this.toggleHidden}
             background={this.getButtonBackground("showhide", label, model, hidden ? "press1" : undefined)}
@@ -182,8 +183,8 @@ export default class Thermoscope extends PureComponent {
             activeBackground={this.getButtonBackground("showhide", label, model, hidden ? "press2" : "hover1")}
           />
         }
-        {showPlayButtons && 
-          <StyledButton 
+        {showPlayButtons &&
+          <StyledButton
             className={`play-pause ${label.toLowerCase()}`}
             onClick={this.togglePause}
             background={this.getButtonBackground("playpause", label, model, paused ? "press1" : undefined)}

--- a/js/components/thermoscope.js
+++ b/js/components/thermoscope.js
@@ -125,6 +125,10 @@ export default class Thermoscope extends PureComponent {
     let showClass = hidden ? "hidden" : "shown";
     let tempScale = paused ? zeroTempScale : model.tempScale;
 
+    // if mixing without live sensors, simulate a median temperature
+    let mixingTemperature = mixingValues && !liveData ? (Math.abs(mixingValues.aTemp - mixingValues.bTemp) / 2) + Math.min(mixingValues.aTemp, mixingValues.bTemp) : temperature;
+    let calculatedTemperature = mixingValues ? mixingTemperature : temperature;
+
     // a url parameter will override the props setting
     if (SHOW_MATERIAL_CONTROLS != null) showControls = showControlsParam;
 
@@ -134,7 +138,7 @@ export default class Thermoscope extends PureComponent {
         <div className={`label ${label.toLowerCase()} ${this.modelToClassName(model)}`} />
         {!hidden && [
             !frozen &&
-              <LabModel temperature={temperature}
+              <LabModel temperature={calculatedTemperature}
                 model={model.json}
                 tempScale={tempScale}
                 timeStepScale={model.timeStepScale}
@@ -149,7 +153,7 @@ export default class Thermoscope extends PureComponent {
             <div className={`zoom-circle ${label.toLowerCase()} ${this.modelToClassName(model)}`} key="circle"/>,
             <Dial
               className={`${className ? className : ''} ${label.toLowerCase()} ${this.modelToClassName(model)}`}
-              temperature={temperature}
+              temperature={calculatedTemperature}
               showCelsius={showCelsius}
               onUpdateTemp={this.handleTemperatureChange}
               minTemp={-6}
@@ -162,7 +166,7 @@ export default class Thermoscope extends PureComponent {
             (isFinite(bPegged) &&
               <Dial
                 className={`${className} ${label.toLowerCase()} ${this.modelToClassName(model)} dial2`}
-                temperature={temperature}
+                temperature={calculatedTemperature}
                 showCelsius={showCelsius}
                 onUpdateTemp={this.handleTemperatureChange}
                 minTemp={-6}

--- a/js/components/thermoscope.js
+++ b/js/components/thermoscope.js
@@ -109,7 +109,7 @@ export default class Thermoscope extends PureComponent {
 
   render() {
     const { temperature, materialType, materialIdx, liveData, label, paused, hidden } = this.state;
-    const { embeddableSrc, showMaterialControls, showHideButtons, showPlayButtons, showCelsius, className, aPegged, bPegged, forceCover, frozen, mixingValues } = this.props;
+    const { embeddableSrc, showMaterialControls, showHideButtons, showPlayButtons, showCelsius, className, aPegged, bPegged, forceCover, frozen } = this.props;
 
     const model = models[materialType][materialIdx];
     let material = MATERIAL_TYPES.indexOf(materialType > -1) ? materialType : 'solid';
@@ -125,10 +125,11 @@ export default class Thermoscope extends PureComponent {
     let showClass = hidden ? "hidden" : "shown";
     let tempScale = paused ? zeroTempScale : model.tempScale;
 
+    let isMixing = isFinite(aPegged) && isFinite(bPegged);
     // if mixing without live sensors, simulate a median temperature
-    let mixingTemperature = mixingValues && !liveData ? (Math.abs(mixingValues.aTemp - mixingValues.bTemp) / 2) + Math.min(mixingValues.aTemp, mixingValues.bTemp) : temperature;
-    let calculatedTemperature = mixingValues ? mixingTemperature : temperature;
-
+    let calculatedTemperature = isMixing && !liveData ? Math.round((aPegged + bPegged) / 2) : temperature;
+    // Need to pass both values to Lab to simulate the mixing process
+    let mixingValues = isMixing ? { aTemp: aPegged, bTemp: bPegged } : undefined;
     // a url parameter will override the props setting
     if (SHOW_MATERIAL_CONTROLS != null) showControls = showControlsParam;
 


### PR DESCRIPTION
Adjust the rate of mixing between two different temperature liquids for the mixing experiment to gradually come to temperature over time - there's a fight between the lab instance and the passed temperature and the KE added in the tick handler, but the end result is that the cooler substance particles are slowed, the warmer substance molecules are faster.
Added some edge-case handlers for the crazy scientists who put their probes in water over 60 degrees since the increased acceleration can cause lab to crash (model diverge errors). 
Mixing meters are draggable when not connected to a live thermoscope.